### PR TITLE
use of <context:property-placeholder/> will help docker containerization easier

### DIFF
--- a/geoportal/src/main/resources/config/app-context.xml
+++ b/geoportal/src/main/resources/config/app-context.xml
@@ -6,6 +6,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
+	<context:property-placeholder/>
 	<context:annotation-config />
 	<context:component-scan base-package="com.esri.geoportal" />
 
@@ -26,7 +27,7 @@
 		<beans:property name="nodes">
 			<!-- The list of host names within the Elasticsearch cluster, one value element per host -->
 			<beans:list>
-				<beans:value>localhost</beans:value>
+				<beans:value>${es_node:localhost}</beans:value>
 			</beans:list>
 		</beans:property>
 	</beans:bean>


### PR DESCRIPTION
if values can be picked up from OS environment variables, it makes job easier to deploy in docker containers through compose, swarm, mesos.

https://github.com/ArcGIS/geoportal-server-catalog-docker-compose-swarm