### PR TITLE
#19 Some data.gov csw transforms use 9999 as null date.

### DIFF
--- a/geoportal/src/main/resources/metadata/js/EvaluatorBase.js
+++ b/geoportal/src/main/resources/metadata/js/EvaluatorBase.js
@@ -50,17 +50,21 @@ var G = {
       }
     }
     if (params.begin) {
-      data["begin_dt"] = this.DateUtil.checkIsoDateTime(params.begin.date,false);
+      if (typeof params.begin.date === "string" && !params.begin.date.startsWith("9999")) {
+        data["begin_dt"] = this.DateUtil.checkIsoDateTime(params.begin.date,false);
+      }
       data["begin_indeterminate_s"] = this.Val.chkStr(params.begin.indeterminate,null);
     }
     if (params.end) {
-      data["end_dt"] = this.DateUtil.checkIsoDateTime(params.end.date,true);
+      if (typeof params.end.date === "string" && !params.end.date.startsWith("9999")) {
+        data["end_dt"] = this.DateUtil.checkIsoDateTime(params.end.date,true);
+      }
       data["end_indeterminate_s"] = this.Val.chkStr(params.end.indeterminate,null);
     }
     var ok = false;
     for (var k in data) {
       if (data.hasOwnProperty(k)) {
-        if (data[k] !== null && !data[k].startsWith("9999")) {
+        if (data[k] !== null ) {
           ok = true;
           break;
         }

--- a/geoportal/src/main/resources/metadata/js/EvaluatorBase.js
+++ b/geoportal/src/main/resources/metadata/js/EvaluatorBase.js
@@ -60,7 +60,7 @@ var G = {
     var ok = false;
     for (var k in data) {
       if (data.hasOwnProperty(k)) {
-        if (data[k] !== null) {
+        if (data[k] !== null && !data[k].startsWith("9999")) {
           ok = true;
           break;
         }


### PR DESCRIPTION
Prevents elements with 9999 at the start of a string.