### PR TITLE
F/jetty buffer

### DIFF
--- a/geoportal/src/main/java/com/esri/geoportal/base/util/BalancerSupport.java
+++ b/geoportal/src/main/java/com/esri/geoportal/base/util/BalancerSupport.java
@@ -31,10 +31,6 @@ public class BalancerSupport {
   protected final AtomicLong balancerCount = new AtomicLong();
   private List<BalancerNode> balancerNodes = new ArrayList<>();
   private boolean is7Plus;
-  
-  /** Constructor. */
-  public BalancerSupport() {
-  }
 
   public boolean getIs7Plus() {
     return is7Plus;

--- a/geoportal/src/main/java/com/esri/geoportal/base/util/BalancerSupport.java
+++ b/geoportal/src/main/java/com/esri/geoportal/base/util/BalancerSupport.java
@@ -16,13 +16,11 @@ package com.esri.geoportal.base.util;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.servlet.http.HttpServletRequest;
 
-import org.eclipse.jetty.client.HttpClient;
 
 /**
  * Supports forward proxy load balancing to a cluster of nodes.
@@ -35,7 +33,8 @@ public class BalancerSupport {
   private boolean is7Plus;
   
   /** Constructor. */
-  public BalancerSupport() {}
+  public BalancerSupport() {
+  }
 
   public boolean getIs7Plus() {
     return is7Plus;
@@ -53,19 +52,19 @@ public class BalancerSupport {
   public void getBalancerNodes(List<BalancerNode> balancerNodes) {
     this.balancerNodes = balancerNodes;
   }
-  
-  /**
-   * Make a new HTTP client
-   * @return the client
-   */
-  public HttpClient newHttpClient() {
-    HttpClient client = new HttpClient();
-    // TODO HttpProxy??
-    //HttpProxy proxy = new HttpProxy("localhost",8888);
-    //ProxyConfiguration proxyConfig = client.getProxyConfiguration();
-    //proxyConfig.getProxies().add(proxy);
-    return client;
-  }
+//  
+//  /**
+//   * Make a new HTTP client
+//   * @return the client
+//   */
+//  public HttpClient newHttpClient() {
+//    HttpClient client = new HttpClient();
+//    // TODO HttpProxy??
+//    //HttpProxy proxy = new HttpProxy("localhost",8888);
+//    //ProxyConfiguration proxyConfig = client.getProxyConfiguration();
+//    //proxyConfig.getProxies().add(proxy);
+//    return client;
+//  }
   
   /**
    * Rewrite the target url for a request.

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticContext.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticContext.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
  * Elasticsearch context.
  */
 public class ElasticContext {
+  private static final int DEFAULT_PROXY_BUFFER_SIZE = 4096;
 
   /** Logger. */
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticContext.class);
@@ -82,8 +83,26 @@ public class ElasticContext {
   private String xpackSslCertificate = null;
   private String xpackSslCertificateAuthorities = null;
   
+  private Integer proxyBufferSize = DEFAULT_PROXY_BUFFER_SIZE;
+  
   /** Constructor */
   public ElasticContext() {}
+  
+  /**
+   * Gest proxy buffer size.
+   * @return buffer size
+   */
+  public Integer getProxyBufferSize() {
+    return proxyBufferSize;
+  }
+
+  /**
+   * Sets proxy buffer size.
+   * @param proxyBufferSize buffer size or <code>null</code> for default
+   */
+  public void setProxyBufferSize(Integer proxyBufferSize) {
+    this.proxyBufferSize = proxyBufferSize!=null? proxyBufferSize: DEFAULT_PROXY_BUFFER_SIZE;
+  }
   
   /** Allow internal metadata file idenitfiers to be used as the Elasticsearch _id .*/
   public boolean getAllowFileId() {

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
@@ -40,6 +40,9 @@ public class ElasticProxy extends BalancerServlet {
   private final BalancerSupport balancerSupport = new BalancerSupport();
   private String _authString = null;
   private boolean _useHttps = false;
+
+  public ElasticProxy() {
+  }
   
   @Override
   protected void copyRequestHeaders(HttpServletRequest clientRequest, Request proxyRequest) {
@@ -99,13 +102,13 @@ public class ElasticProxy extends BalancerServlet {
   
   @Override
   protected HttpClient newHttpClient() {
+    SslContextFactory factory = null;
     if (this._useHttps) {
-      SslContextFactory factory = new SslContextFactory();
+      factory = new SslContextFactory();
       factory.setTrustAll(true);
-      return new HttpClient(factory);
     }
     //return balancerSupport.newHttpClient();
-    HttpClient client = new HttpClient();
+    HttpClient client = factory!=null? new HttpClient(factory): new HttpClient();
 //    org.eclipse.jetty.client.HttpProxy proxy = new org.eclipse.jetty.client.HttpProxy("localhost",8888);
 //    org.eclipse.jetty.client.ProxyConfiguration proxyConfig = client.getProxyConfiguration();
 //    proxyConfig.getProxies().add(proxy);

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
@@ -41,9 +41,6 @@ public class ElasticProxy extends BalancerServlet {
   private String _authString = null;
   private boolean _useHttps = false;
   private Integer proxyBufferSize = null;
-
-  public ElasticProxy() {
-  }
   
   @Override
   protected void copyRequestHeaders(HttpServletRequest clientRequest, Request proxyRequest) {

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/ElasticProxy.java
@@ -40,6 +40,7 @@ public class ElasticProxy extends BalancerServlet {
   private final BalancerSupport balancerSupport = new BalancerSupport();
   private String _authString = null;
   private boolean _useHttps = false;
+  private Integer proxyBufferSize = null;
 
   public ElasticProxy() {
   }
@@ -63,6 +64,13 @@ public class ElasticProxy extends BalancerServlet {
   @Override
   public void init() throws ServletException {
     LOGGER.debug("Starting up ElasticProxy...");
+    GeoportalContext gc = GeoportalContext.getInstance();
+    if (gc!=null) {
+      ElasticContext ec = gc.getElasticContext();
+      if (ec!=null) {
+        proxyBufferSize = ec.getProxyBufferSize();
+      }
+    }
     initBalancerNodes();
     super.init();
   }
@@ -107,8 +115,11 @@ public class ElasticProxy extends BalancerServlet {
       factory = new SslContextFactory();
       factory.setTrustAll(true);
     }
-    //return balancerSupport.newHttpClient();
     HttpClient client = factory!=null? new HttpClient(factory): new HttpClient();
+    if (proxyBufferSize!=null) {
+      LOGGER.debug(String.format("Buffer size for HTTP client for ElasticProxi set to: %s bytes", proxyBufferSize));
+      client.setRequestBufferSize(proxyBufferSize);
+    }
 //    org.eclipse.jetty.client.HttpProxy proxy = new org.eclipse.jetty.client.HttpProxy("localhost",8888);
 //    org.eclipse.jetty.client.ProxyConfiguration proxyConfig = client.getProxyConfiguration();
 //    proxyConfig.getProxies().add(proxy);

--- a/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HarvesterProxy extends BalancerServlet {
   private static final Logger LOGGER = LoggerFactory.getLogger(HarvesterProxy.class);
-  private final BalancerSupport balancerSupport = new BalancerSupport();
+  private BalancerSupport balancerSupport = new BalancerSupport();
 
   public HarvesterProxy() {
   }

--- a/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
@@ -29,9 +29,6 @@ public class HarvesterProxy extends BalancerServlet {
   private static final Logger LOGGER = LoggerFactory.getLogger(HarvesterProxy.class);
   private BalancerSupport balancerSupport = new BalancerSupport();
 
-  public HarvesterProxy() {
-  }
-
   @Override
   public void init() throws ServletException {
     super.init();

--- a/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/harvester/HarvesterProxy.java
@@ -29,6 +29,9 @@ public class HarvesterProxy extends BalancerServlet {
   private static final Logger LOGGER = LoggerFactory.getLogger(HarvesterProxy.class);
   private final BalancerSupport balancerSupport = new BalancerSupport();
 
+  public HarvesterProxy() {
+  }
+
   @Override
   public void init() throws ServletException {
     super.init();

--- a/geoportal/src/main/resources/config/app-context.xml
+++ b/geoportal/src/main/resources/config/app-context.xml
@@ -39,6 +39,7 @@ see: docs/configureByEnvironmentVariable.md
 		<beans:property name="mappingsFile7" value="${gpt_mappingsFile:config/elastic-mappings-7.json}" />
 		<beans:property name="httpPort" value="9200" />
 		<beans:property name="transportPort" value="9300" />
+		<beans:property name="proxyBufferSize" value="8192" />
 		
 		<!-- complete the following if you have x-pack security enabled,
 		     see https://www.elastic.co/guide/en/x-pack/current/java-clients.html -->


### PR DESCRIPTION
## Ability to change Jetty request buffer size.
### Configuration

1. Open "app-context.xml" configuration file in text editor,
2. Locate "elasticContext" bean,
3. Update value of the "proxyBufferSize" property:
    - Default value is 4096 bytes,
    - Recommended value is 8192 bytes.