### PR TITLE
Indexing _json component disabled.

### DIFF
--- a/geoportal/src/main/resources/config/elastic-mappings-7.json
+++ b/geoportal/src/main/resources/config/elastic-mappings-7.json
@@ -90,6 +90,10 @@
       },
       "description": {
         "type": "text"
+      },
+      "_json": {
+        "type": "object",
+        "enabled": false
       }
     },
     "dynamic_templates":[

--- a/geoportal/src/main/resources/config/elastic-mappings.json
+++ b/geoportal/src/main/resources/config/elastic-mappings.json
@@ -91,6 +91,10 @@
         },
         "description": {
           "type": "text"
+        },
+        "_json": {
+          "type": "object",
+          "enabled": false
         }
       },
       "dynamic_templates":[


### PR DESCRIPTION
### Indexing "_json" componend is disabled.
## Overview
Typically, when harvesting data in JSON format, this data is stored under additional property within Elastic Search record and that property is named "_json". It may happen that two different sources will provide such information that it coindentialy has one or more properties named in the same way but of different types, for example: property "date" could be expressed as ISO date string in first case but count of milliseconds (UNIX date) as numerical value.

When first source is being harvested it will create mapping for the "date" property and it will declare it as string. If the second source is being harvested it will fail since it's "date" property doesn't conform to the previously created type in mappings.

Generally, it is safe to disable indexing for "_json" property since it is meant to be used as a reference only and it doesn't participate in any search procedures.