### PR TITLE
Explicit Nashorn dependency

### DIFF
--- a/geoportal/pom.xml
+++ b/geoportal/pom.xml
@@ -214,6 +214,13 @@
       <artifactId>commons-io</artifactId>
       <version>2.8.0</version>
     </dependency>
+    
+    <!-- Nashorn JavaScript engine  -->
+    <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.2</version>
+    </dependency>
    
   </dependencies> 
   


### PR DESCRIPTION
Adding Nashorn dependency allows to upgrade JDK beyond version 11.