### PR TITLE
Basic implementation of collections

### DIFF
--- a/geoportal/src/main/java/com/esri/geoportal/context/GeoportalContext.java
+++ b/geoportal/src/main/java/com/esri/geoportal/context/GeoportalContext.java
@@ -54,6 +54,7 @@ public class GeoportalContext implements ApplicationContextAware {
   private boolean supportsGroupBasedAccess = false;
   private String version = "2.6.0";
   private boolean parseGml;
+  private boolean supportsCollections = false;
   
   /** Constructor */
   public GeoportalContext() {}
@@ -151,6 +152,15 @@ public class GeoportalContext implements ApplicationContextAware {
   }
   public void setVersion(String version) {
     this.version = version;
+  }
+  
+  /** Support for collections. */
+  public boolean getSupportsCollections() {
+    return supportsCollections;
+  }
+  /** Support for collections. */
+  public void setSupportsCollections(boolean supportsCollections) {
+    this.supportsCollections = supportsCollections;
   }
   
   /** Methods =============================================================== */

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/http/request/SetCollectionsRequest.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/http/request/SetCollectionsRequest.java
@@ -1,0 +1,112 @@
+/* See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.esri.geoportal.lib.elastic.http.request;
+import com.esri.geoportal.base.util.JsonUtil;
+import com.esri.geoportal.context.AppResponse;
+import com.esri.geoportal.context.GeoportalContext;
+import com.esri.geoportal.lib.elastic.request.BulkEditRequest;
+import com.esri.geoportal.lib.elastic.util.FieldNames;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+
+/**
+ * Set the access level for one or more items.
+ */
+public class SetCollectionsRequest extends BulkEditRequest {
+  
+  /** Constructor. */
+  public SetCollectionsRequest() {
+    super();
+    this.setUseHttpClient(true);
+  }
+  
+  @Override
+  public AppResponse execute() throws Exception {
+//    /*
+//    http://localhost:8080/geoportal/rest/metadata/setAccess?id=68e65338e166458d8425775114487b31&access=private&group=g1&group=g2
+//    
+//    access=&group=&group=
+//    */
+//    
+//    setAdminOnly(false);
+//    setProcessMessage("SetAccess");
+//    AppResponse response = new AppResponse();
+//    if (!GeoportalContext.getInstance().getSupportsGroupBasedAccess()) {
+//      String msg = "Not implemented";
+//      response.writeNotImplemented(this,JsonUtil.newErrorResponse(msg,getPretty()));
+//      return response;
+//    }
+//    
+//    boolean hasGroups = false;
+//    String[] groups = getParameterValues("group");
+//    if (groups != null && groups.length == 1) {
+//      // TODO check comma delimited?
+//    }
+//    JsonArrayBuilder jsaGroups = Json.createArrayBuilder();
+//    if (groups != null) {
+//      for (String group: groups) {
+//        if (group != null) group = group.trim();
+//        if (group != null && group.length() > 0) {
+//          jsaGroups.add(group);
+//          hasGroups = true;
+//        }
+//      }         
+//    }
+//    
+//    String access = getParameter("access");
+//    if (access != null) access = access.trim();
+//    if (access == null || access.length() == 0) {
+//      if (hasGroups) {
+//        access = "private";
+//      } else {
+//        response.writeMissingParameter(this,"access");
+//        return response;
+//      }
+//    }
+//    access = access.toLowerCase();
+//    if (!access.equals("public") && !access.equals("private")) {
+//      String msg = "access must be public or private";
+//      response.writeBadRequest(this,JsonUtil.newErrorResponse(msg,getPretty()));
+//      return response;
+//    }
+//    /*
+//    // TODO should this be enforced? 
+//    if (access.equals("public") && hasGroups) {
+//      String msg = "access must be private when groups are specified";
+//      response.writeBadRequest(this,JsonUtil.newErrorResponse(msg,getPretty()));
+//      return response;
+//    }
+//    */
+//    
+//    JsonObjectBuilder jso = Json.createObjectBuilder();
+//    jso.add(FieldNames.FIELD_SYS_ACCESS,access);
+//    if (hasGroups) {
+//      jso.add(FieldNames.FIELD_SYS_ACCESS_GROUPS,jsaGroups);
+//    } else {
+//      // TODO? is null or empty array better?
+//      jso.addNull(FieldNames.FIELD_SYS_ACCESS_GROUPS);
+//    }
+//    
+//    //jso.add(FieldNames.FIELD_SYS_MODIFIED,DateUtil.nowAsString()); // TODO should this be set?
+//    setUpdateSource(jso.build().toString());
+//    
+//    //System.err.println("updateSource="+this.getUpdateSource());
+//    //if (true) throw new RuntimeException("SetAccessRequest: temporary stop");
+    return super.execute();
+  }
+  
+}

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/http/request/SetCollectionsRequest.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/http/request/SetCollectionsRequest.java
@@ -18,6 +18,7 @@ import com.esri.geoportal.context.AppResponse;
 import com.esri.geoportal.context.GeoportalContext;
 import com.esri.geoportal.lib.elastic.request.BulkEditRequest;
 import com.esri.geoportal.lib.elastic.util.FieldNames;
+import java.util.Arrays;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -36,76 +37,35 @@ public class SetCollectionsRequest extends BulkEditRequest {
   
   @Override
   public AppResponse execute() throws Exception {
-//    /*
-//    http://localhost:8080/geoportal/rest/metadata/setAccess?id=68e65338e166458d8425775114487b31&access=private&group=g1&group=g2
-//    
-//    access=&group=&group=
-//    */
-//    
-//    setAdminOnly(false);
-//    setProcessMessage("SetAccess");
-//    AppResponse response = new AppResponse();
-//    if (!GeoportalContext.getInstance().getSupportsGroupBasedAccess()) {
-//      String msg = "Not implemented";
-//      response.writeNotImplemented(this,JsonUtil.newErrorResponse(msg,getPretty()));
-//      return response;
-//    }
-//    
-//    boolean hasGroups = false;
-//    String[] groups = getParameterValues("group");
-//    if (groups != null && groups.length == 1) {
-//      // TODO check comma delimited?
-//    }
-//    JsonArrayBuilder jsaGroups = Json.createArrayBuilder();
-//    if (groups != null) {
-//      for (String group: groups) {
-//        if (group != null) group = group.trim();
-//        if (group != null && group.length() > 0) {
-//          jsaGroups.add(group);
-//          hasGroups = true;
-//        }
-//      }         
-//    }
-//    
-//    String access = getParameter("access");
-//    if (access != null) access = access.trim();
-//    if (access == null || access.length() == 0) {
-//      if (hasGroups) {
-//        access = "private";
-//      } else {
-//        response.writeMissingParameter(this,"access");
-//        return response;
-//      }
-//    }
-//    access = access.toLowerCase();
-//    if (!access.equals("public") && !access.equals("private")) {
-//      String msg = "access must be public or private";
-//      response.writeBadRequest(this,JsonUtil.newErrorResponse(msg,getPretty()));
-//      return response;
-//    }
-//    /*
-//    // TODO should this be enforced? 
-//    if (access.equals("public") && hasGroups) {
-//      String msg = "access must be private when groups are specified";
-//      response.writeBadRequest(this,JsonUtil.newErrorResponse(msg,getPretty()));
-//      return response;
-//    }
-//    */
-//    
-//    JsonObjectBuilder jso = Json.createObjectBuilder();
-//    jso.add(FieldNames.FIELD_SYS_ACCESS,access);
-//    if (hasGroups) {
-//      jso.add(FieldNames.FIELD_SYS_ACCESS_GROUPS,jsaGroups);
-//    } else {
-//      // TODO? is null or empty array better?
-//      jso.addNull(FieldNames.FIELD_SYS_ACCESS_GROUPS);
-//    }
-//    
-//    //jso.add(FieldNames.FIELD_SYS_MODIFIED,DateUtil.nowAsString()); // TODO should this be set?
-//    setUpdateSource(jso.build().toString());
-//    
-//    //System.err.println("updateSource="+this.getUpdateSource());
-//    //if (true) throw new RuntimeException("SetAccessRequest: temporary stop");
+    /*
+    http://localhost:8080/geoportal/rest/metadata/setCollections?id=68e65338e166458d8425775114487b31&collections=collection1,collection2
+    
+    collections=
+    */
+    
+    setAdminOnly(false);
+    setProcessMessage("SetCollections");
+    AppResponse response = new AppResponse();
+    if (!GeoportalContext.getInstance().getSupportsCollections()) {
+      String msg = "Not implemented";
+      response.writeNotImplemented(this,JsonUtil.newErrorResponse(msg,getPretty()));
+      return response;
+    }
+    
+    JsonObjectBuilder jso = Json.createObjectBuilder();
+    
+    String collectionsStr = getParameter("collections");
+    if (collectionsStr != null) {
+      collectionsStr = collectionsStr.trim();
+      String [] collections = collectionsStr.split(",");
+      
+      JsonArrayBuilder arrBuilder = Json.createArrayBuilder();
+      Arrays.stream(collections).forEach(coll -> arrBuilder.add(coll));
+      
+      jso.add(FieldNames.FIELD_SYS_COLLECTIONS,arrBuilder);
+    }
+    
+    setUpdateSource(jso.build().toString());
     return super.execute();
   }
   

--- a/geoportal/src/main/java/com/esri/geoportal/lib/elastic/util/FieldNames.java
+++ b/geoportal/src/main/java/com/esri/geoportal/lib/elastic/util/FieldNames.java
@@ -72,6 +72,9 @@ public class FieldNames {
   /** FIELD_SYS_XMLMODIFIED = "sys_xmlmodified_dt" */
   public static String FIELD_SYS_XMLMODIFIED = "sys_xmlmodified_dt";
   
+  /** FIELD_SYS_COLLECTIONS = "sys_collections_s" */
+  public static String FIELD_SYS_COLLECTIONS = "sys_collections_s";
+  
   /* sys (kvp) ===================================================== */
   
   /** FIELD_SYS_BLOB = "sys_blob" */

--- a/geoportal/src/main/java/com/esri/geoportal/service/rest/GeoportalService.java
+++ b/geoportal/src/main/java/com/esri/geoportal/service/rest/GeoportalService.java
@@ -71,6 +71,7 @@ public class GeoportalService {
       jso.add("metadataIndexName",gc.getElasticContext().getItemIndexName());
       jso.add("supportsApprovalStatus",gc.getSupportsApprovalStatus());
       jso.add("supportsGroupBasedAccess",gc.getSupportsGroupBasedAccess());
+      jso.add("supportsCollections",gc.getSupportsCollections());
       
       if (user != null && user.getUsername() != null) {
         JsonObjectBuilder jsoUser = Json.createObjectBuilder()

--- a/geoportal/src/main/java/com/esri/geoportal/service/rest/MetadataService.java
+++ b/geoportal/src/main/java/com/esri/geoportal/service/rest/MetadataService.java
@@ -16,6 +16,7 @@ package com.esri.geoportal.service.rest;
 import com.esri.geoportal.context.AppResponse;
 import com.esri.geoportal.context.AppUser;
 import com.esri.geoportal.context.GeoportalContext;
+import com.esri.geoportal.lib.elastic.http.request.SetCollectionsRequest;
 import com.esri.geoportal.lib.elastic.request.DeleteItemRequest;
 import com.esri.geoportal.lib.elastic.request.DeleteItemsRequest;
 import com.esri.geoportal.lib.elastic.request.GetItemRequest;
@@ -271,6 +272,27 @@ public class MetadataService {
     try {
       SetApprovalStatusRequest request = GeoportalContext.getInstance().getBean(
           "request.SetApprovalStatusRequest",SetApprovalStatusRequest.class);
+      request.init(user,pretty);
+      request.setParameterMap(hsr.getParameterMap());
+      request.setBody(body);
+      AppResponse response = request.execute();
+      return response.build();
+    } catch (Throwable t) {
+      return this.writeException(t,pretty);
+    }
+  }
+  
+  @PUT
+  @Path("/setCollections")
+  public Response setCollections(
+      String body,
+      @Context SecurityContext sc,
+      @Context HttpServletRequest hsr,
+      @QueryParam("pretty") boolean pretty) {
+    AppUser user = new AppUser(hsr,sc);
+    try {
+      SetCollectionsRequest request = GeoportalContext.getInstance().getBean(
+          "request.SetCollectionsRequest",SetCollectionsRequest.class);
       request.init(user,pretty);
       request.setParameterMap(hsr.getParameterMap());
       request.setBody(body);

--- a/geoportal/src/main/resources/config/app-context.xml
+++ b/geoportal/src/main/resources/config/app-context.xml
@@ -21,6 +21,7 @@
 		<beans:property name="supportsGroupBasedAccess" value="false" />
 		<beans:property name="defaultAccessLevel" value="" /> <!-- optional - public|private -->
 		<beans:property name="parseGml" value="false" />
+		<beans:property name="supportsCollections" value="false" />
 	</beans:bean>
 <!-- the tokens like ${es_cluster:elasticsearch} ${gpt_indexName:metadata}
 represent environment variables that can be used to pass values into a spring configuration context, aka these files

--- a/geoportal/src/main/resources/config/app-factory.xml
+++ b/geoportal/src/main/resources/config/app-factory.xml
@@ -14,6 +14,7 @@
   <beans:bean id="request.RealiasRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.RealiasRequest"/>
   <beans:bean id="request.ReindexRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.ReindexRequest"/>
   <beans:bean id="request.SetAccessRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.SetAccessRequest"/>
+  <beans:bean id="request.SetCollectionsRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.SetCollectionsRequest"/>
   <beans:bean id="request.SetApprovalStatusRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.SetApprovalStatusRequest"/>
   <beans:bean id="request.SetFieldRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.SetFieldRequest"/>
   <beans:bean id="request.SetOwnerRequest" scope="prototype" class="com.esri.geoportal.lib.elastic.http.request.SetOwnerRequest"/>

--- a/geoportal/src/main/webapp/app/content/SetCollections.js
+++ b/geoportal/src/main/webapp/app/content/SetCollections.js
@@ -1,0 +1,81 @@
+/* See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(["dojo/_base/declare",
+  "dojo/topic",
+  "app/context/app-topics",
+  "app/content/BulkEdit",
+  "dojo/text!./templates/SetCollections.html",
+  "dojo/i18n!app/nls/resources",
+  "app/content/ApplyTo"],
+function(declare, topic, appTopics, BulkEdit, template, i18n, ApplyTo) {
+
+  var oThisClass = declare([BulkEdit], {
+    
+    i18n: i18n,
+    templateString: template,
+    
+    title: i18n.content.setCollections.caption,
+    okLabel: i18n.content.updateButton,
+    
+    _localValue: null,
+
+    postCreate: function() {
+      this.inherited(arguments);
+    },
+    
+    applyLocally: function(item) {
+      //item["sys_approval_status_s"] = this._localValue;
+      //topic.publish(appTopics.ItemApprovalStatusChanged,{item:item});
+      topic.publish(appTopics.RefreshSearchResultPage,{
+        searchPane: this.itemCard.searchPane
+      });
+    },
+    
+    init: function() {
+      this.setNodeText(this.itemTitleNode,this.item.title);
+      if (!AppContext.appUser.isAdmin()) {
+        $(this.statusSelect).find("option[value='approved']").remove();
+        $(this.statusSelect).find("option[value='reviewed']").remove();
+        $(this.statusSelect).find("option[value='disapproved']").remove();
+      }
+      var v = this.item["sys_approval_status_s"];
+      if (typeof v === "string" && v.length > 0) {
+        $(this.statusSelect).val(v);
+      }
+      this.applyTo = new ApplyTo({
+        item: this.item,
+        itemCard: this.itemCard,
+      },this.applyToNode);
+    },
+    
+    makeRequestParams: function() {
+      var params = {
+        action: "setApprovalStatus",
+        urlParams: {}
+      };
+      var status = $(this.statusSelect).val();
+      if (typeof status !== "string" || status === "" || status === "none") {
+        this.statusSelect.focus();
+        return null;
+      }
+      this._localValue = params.urlParams.approvalStatus = status;
+      this.applyTo.appendUrlParams(params);
+      return params;
+    }
+
+  });
+
+  return oThisClass;
+});

--- a/geoportal/src/main/webapp/app/content/SetCollections.js
+++ b/geoportal/src/main/webapp/app/content/SetCollections.js
@@ -36,8 +36,6 @@ function(declare, topic, appTopics, BulkEdit, template, i18n, ApplyTo) {
     },
     
     applyLocally: function(item) {
-      //item["sys_approval_status_s"] = this._localValue;
-      //topic.publish(appTopics.ItemApprovalStatusChanged,{item:item});
       topic.publish(appTopics.RefreshSearchResultPage,{
         searchPane: this.itemCard.searchPane
       });
@@ -45,14 +43,11 @@ function(declare, topic, appTopics, BulkEdit, template, i18n, ApplyTo) {
     
     init: function() {
       this.setNodeText(this.itemTitleNode,this.item.title);
-      if (!AppContext.appUser.isAdmin()) {
-        $(this.statusSelect).find("option[value='approved']").remove();
-        $(this.statusSelect).find("option[value='reviewed']").remove();
-        $(this.statusSelect).find("option[value='disapproved']").remove();
-      }
-      var v = this.item["sys_approval_status_s"];
+      var v = this.item["sys_collections_s"];
       if (typeof v === "string" && v.length > 0) {
-        $(this.statusSelect).val(v);
+        $(this.collectionsValueInput).val(v);
+      } else if (Array.isArray(v)) {
+        $(this.collectionsValueInput).val(v.join(","));
       }
       this.applyTo = new ApplyTo({
         item: this.item,
@@ -65,12 +60,12 @@ function(declare, topic, appTopics, BulkEdit, template, i18n, ApplyTo) {
         action: "setCollections",
         urlParams: {}
       };
-      var status = $(this.statusSelect).val();
+      var status = $(this.collectionsValueInput).val();
       if (typeof status !== "string" || status === "" || status === "none") {
-        this.statusSelect.focus();
+        this.collectionsValueInput.focus();
         return null;
       }
-      this._localValue = params.urlParams.approvalStatus = status;
+      this._localValue = params.urlParams.collections = status;
       this.applyTo.appendUrlParams(params);
       return params;
     }

--- a/geoportal/src/main/webapp/app/content/SetCollections.js
+++ b/geoportal/src/main/webapp/app/content/SetCollections.js
@@ -62,7 +62,7 @@ function(declare, topic, appTopics, BulkEdit, template, i18n, ApplyTo) {
     
     makeRequestParams: function() {
       var params = {
-        action: "setApprovalStatus",
+        action: "setCollections",
         urlParams: {}
       };
       var status = $(this.statusSelect).val();

--- a/geoportal/src/main/webapp/app/content/templates/SetCollections.html
+++ b/geoportal/src/main/webapp/app/content/templates/SetCollections.html
@@ -1,0 +1,21 @@
+<div>
+  <div class="form-group" data-dojo-attach-point="itemTitleNode"></div>
+  <div class="form-group form-group-sm">
+    <div>
+	    <label for="${id}_sel1" class="control-label"
+	      >${i18n.content.setApprovalStatus.status}</label>
+    </div>
+    <div>
+      <select id="${id}_sel1" class="form-control" data-dojo-attach-point="statusSelect">
+        <option value="none"></option>
+        <option value="approved">${i18n.content.setApprovalStatus.approved}</option>
+        <option value="reviewed">${i18n.content.setApprovalStatus.reviewed}</option>
+        <option value="disapproved">${i18n.content.setApprovalStatus.disapproved}</option>
+        <option value="incomplete">${i18n.content.setApprovalStatus.incomplete}</option>
+        <option value="posted">${i18n.content.setApprovalStatus.posted}</option>
+        <option value="draft">${i18n.content.setApprovalStatus.draft}</option>
+      </select>
+    </div>
+  </div>
+  <div data-dojo-attach-point="applyToNode"></div>
+</div>

--- a/geoportal/src/main/webapp/app/content/templates/SetCollections.html
+++ b/geoportal/src/main/webapp/app/content/templates/SetCollections.html
@@ -3,18 +3,11 @@
   <div class="form-group form-group-sm">
     <div>
 	    <label for="${id}_sel1" class="control-label"
-	      >${i18n.content.setApprovalStatus.status}</label>
+	      >${i18n.content.setCollections.collections}</label>
     </div>
     <div>
-      <select id="${id}_sel1" class="form-control" data-dojo-attach-point="statusSelect">
-        <option value="none"></option>
-        <option value="approved">${i18n.content.setApprovalStatus.approved}</option>
-        <option value="reviewed">${i18n.content.setApprovalStatus.reviewed}</option>
-        <option value="disapproved">${i18n.content.setApprovalStatus.disapproved}</option>
-        <option value="incomplete">${i18n.content.setApprovalStatus.incomplete}</option>
-        <option value="posted">${i18n.content.setApprovalStatus.posted}</option>
-        <option value="draft">${i18n.content.setApprovalStatus.draft}</option>
-      </select>
+      <input id="${id}_tagsValue" type="text" class="form-control input-sm g-input-text" 
+        data-dojo-attach-point="collectionsValueInput" >
     </div>
   </div>
   <div data-dojo-attach-point="applyToNode"></div>

--- a/geoportal/src/main/webapp/app/context/app-topics.js
+++ b/geoportal/src/main/webapp/app/context/app-topics.js
@@ -31,6 +31,9 @@ define([],function(){var obj={
   /* params - {searchPane:obj} */
   RefreshSearchResultPage: "app/RefreshSearchResultPage",
   
+  /* params - {collection:string} */
+  CollectionChanged: "app/CollectionChanged",
+  
   /* params - {geoportalUser:obj} */
   SignedIn: "app/SignedIn",
   

--- a/geoportal/src/main/webapp/app/main/SearchPanel.js
+++ b/geoportal/src/main/webapp/app/main/SearchPanel.js
@@ -29,7 +29,8 @@ define(["dojo/_base/declare",
         "app/search/NumericFilter",
         "app/search/AppliedFilters",
         "app/search/ResultsPane",
-        "app/search/OpenSearchLinksPane"
+        "app/search/OpenSearchLinksPane",
+        "app/search/CollectionsFilter"
       ], 
 function(declare, lang, Templated, template, i18n) {
 

--- a/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
+++ b/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
@@ -30,7 +30,6 @@
 
         <div class="g-filter-collapse" data-dojo-type="app/search/TemporalFilter"
           data-dojo-props="
-            allowedCollections: ['*'],
             nestedPath:'timeperiod_nst',
             field:'timeperiod_nst.begin_dt',
             toField:'timeperiod_nst.end_dt',

--- a/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
+++ b/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
@@ -21,7 +21,11 @@
         </div>
         
         <div class="g-filter-collapse" data-dojo-type="app/search/CollectionsFilter"
-          data-dojo-props="field:'sys_collections_s',open:false,label:'${i18n.search.criteria.collections}'">
+          data-dojo-props="
+            conditionallyDisabled: !AppContext.geoportal.supportsCollections,
+            field:'sys_collections_s',
+            open:false,
+            label:'${i18n.search.criteria.collections}'">
         </div>
 
         <div class="g-filter-collapse" data-dojo-type="app/search/TemporalFilter"

--- a/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
+++ b/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
@@ -19,6 +19,10 @@
             open: true,
             label:'${i18n.search.criteria.map}'">
         </div>
+        
+        <div class="g-filter-collapse" data-dojo-type="app/search/CollectionsFilter"
+          data-dojo-props="field:'sys_collections_s',open:false,label:'${i18n.search.criteria.collections}'">
+        </div>
 
         <div class="g-filter-collapse" data-dojo-type="app/search/TemporalFilter"
           data-dojo-props="

--- a/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
+++ b/geoportal/src/main/webapp/app/main/templates/SearchPanel.html
@@ -30,6 +30,7 @@
 
         <div class="g-filter-collapse" data-dojo-type="app/search/TemporalFilter"
           data-dojo-props="
+            allowedCollections: ['*'],
             nestedPath:'timeperiod_nst',
             field:'timeperiod_nst.begin_dt',
             toField:'timeperiod_nst.end_dt',

--- a/geoportal/src/main/webapp/app/nls/resources.js
+++ b/geoportal/src/main/webapp/app/nls/resources.js
@@ -80,7 +80,8 @@ define({
         accessGroups: "Access Groups",
         missingSource: "Editor/Upload",
         createFilter: "Create Filter",
-        hierarchicalCategory: "Hierarchical Category"
+        hierarchicalCategory: "Hierarchical Category",
+        collections: "Collections"
       },
       componentSettings: {
         componentLabel: "Label",

--- a/geoportal/src/main/webapp/app/nls/resources.js
+++ b/geoportal/src/main/webapp/app/nls/resources.js
@@ -332,6 +332,9 @@ define({
         posted: "Posted",
         draft: "Draft"
       },
+      setCollections: {
+        caption: "Set Collections"
+      },
       setField: {
         caption: "Set Field",
         tags: {

--- a/geoportal/src/main/webapp/app/nls/resources.js
+++ b/geoportal/src/main/webapp/app/nls/resources.js
@@ -333,7 +333,8 @@ define({
         draft: "Draft"
       },
       setCollections: {
-        caption: "Set Collections"
+        caption: "Set Collections",
+        collections: "Collections"
       },
       setField: {
         caption: "Set Field",

--- a/geoportal/src/main/webapp/app/search/AppliedFilter.js
+++ b/geoportal/src/main/webapp/app/search/AppliedFilter.js
@@ -70,6 +70,7 @@ function(declare, lang, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, t
           break;
         }
       }
+      qClause.onChange(false);
       if (nClauseIdx != -1) {
         qClauses.splice(nClauseIdx,1);
         qComp.whenQClauseRemoved(qClause);

--- a/geoportal/src/main/webapp/app/search/AppliedFilters.js
+++ b/geoportal/src/main/webapp/app/search/AppliedFilters.js
@@ -83,6 +83,7 @@ function(declare, lang, array, domConstruct, on, query, domClass, template, i18n
         var aClauses = [];
         array.forEach(component.activeQClauses,function(qClause){
           if (qClause.removable) {
+            qClause.onChange(false);
             component.whenQClauseRemoved(qClause);
           } else {
             aClauses.push(qClause);
@@ -141,6 +142,7 @@ function(declare, lang, array, domConstruct, on, query, domClass, template, i18n
             if (qClause.removable) hasRemovable = true;
             var af = new AppliedFilter({qClause: qClause});
             domConstruct.place(af.domNode, "g-entries-js", "first");
+            qClause.onChange(true);
           }
         });
       });

--- a/geoportal/src/main/webapp/app/search/CollectionsFilter.js
+++ b/geoportal/src/main/webapp/app/search/CollectionsFilter.js
@@ -94,6 +94,7 @@ function(declare, lang, array, domConstruct, template, i18n, SearchComponent,
       var link = domConstruct.create("a",{
         href: "#",
         onclick: lang.hitch(this,function() {
+          this.activeQClauses = null;
           this.pushQClause(qClause,true);
         })
       },nd);

--- a/geoportal/src/main/webapp/app/search/CollectionsFilter.js
+++ b/geoportal/src/main/webapp/app/search/CollectionsFilter.js
@@ -1,0 +1,159 @@
+/* See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(["dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/_base/array",
+        "dojo/dom-construct",
+        "dojo/text!./templates/TermsAggregation.html",
+        "dojo/i18n!app/nls/resources",
+        "app/search/SearchComponent",
+        "app/search/DropPane",
+        "app/search/QClause",
+        "app/search/CollectionsFilterSettings"], 
+function(declare, lang, array, domConstruct, template, i18n, SearchComponent, 
+  DropPane, QClause, CollectionsFilterSettings) {
+  
+  var oThisClass = declare([SearchComponent], {
+    
+    i18n: i18n,
+    templateString: template,
+    
+    allowSettings: null,
+    field: null,
+    label: null,
+    open: false,
+    props: null,
+    
+    _initialSettings: null,
+    
+    postCreate: function() {
+      this.inherited(arguments);
+      
+      this._initialSettings = {
+        label: this.label,
+        field: this.field
+      };
+      if (this.props) {
+        this._initialSettings.props = lang.clone(this.props);
+      }
+      
+      if (this.allowSettings === null) {
+        if (AppContext.appConfig.search && !!AppContext.appConfig.search.allowSettings) {
+          this.allowSettings = true;
+        }
+      }
+      if (this.allowSettings) {
+        var link = this.dropPane.addSettingsLink();
+        link.onclick = lang.hitch(this,function(e) {
+          var d = new CollectionsFilterSettings({
+            targetWidget: this
+          });
+          d.showDialog();
+        });
+      }
+    },
+    
+    postMixInProperties: function() {
+      this.inherited(arguments);
+      if (typeof this.label === "undefined" || this.label === null || this.label.length === 0) {
+        this.label = this.field;
+      }
+    },
+    
+    addEntry: function(term,count,missingVal) {
+      var name = this.chkName(term);
+      var v = name+" ("+count+")";
+      var tipPattern = i18n.search.appliedFilters.tipPattern;
+      var tip = tipPattern.replace("{type}",this.label).replace("{value}",name);
+      var query = {"term": {}};
+      query.term[this.field] = term;
+      if (typeof missingVal === "string" && missingVal.length > 0 && missingVal === term) {
+        query = {"bool": {"must_not": {"exists": {"field": this.field}}}};
+      }
+      var qClause = new QClause({
+        label: name,
+        tip: tip,
+        parentQComponent: this,
+        removable: true,
+        scorable: true,
+        query: query
+      });
+      var nd = domConstruct.create("div",{},this.entriesNode);
+      var link = domConstruct.create("a",{
+        href: "#",
+        onclick: lang.hitch(this,function() {
+          this.pushQClause(qClause,true);
+        })
+      },nd);
+      this.setNodeText(link,v);
+    },
+    
+    chkName: function(term){
+      var name = term;
+      if (this.field === "sys_access_groups_s" && typeof name === "string" &&
+          AppContext.geoportal.supportsGroupBasedAccess) {
+        array.some(AppContext.appUser.getGroups(),function(group){
+          if (group.id === name) {
+            name = group.name;
+            return true;
+          }
+        });
+      }
+      return name;
+    },
+    
+    hasField: function() {
+      return (typeof this.field !== "undefined" && this.field !== null && this.field.length > 0);
+    },
+    
+    /* SearchComponent API ============================================= */
+    
+    appendQueryParams: function(params) {
+      if (!this.hasField()) return;
+      this.appendQClauses(params);
+      
+      if (!params.aggregations) params.aggregations = {};
+      var key = this.getAggregationKey();
+      var props = {"field":this.field};
+      if (typeof this.props !== "undefined" && this.props !== null) {
+        delete this.props.field; // TODO ??
+        lang.mixin(props,this.props);
+      }
+      params.aggregations[key] = {"terms":props};
+    },
+    
+    processResults: function(searchResponse) {
+      domConstruct.empty(this.entriesNode);
+      var key = this.getAggregationKey();
+      if (searchResponse.aggregations) {
+        var data = searchResponse.aggregations[key];
+        if (data && data.buckets) {
+          
+          var v, missingVal = null;
+          if (this.props && typeof this.props.missing === "string") {
+            v = lang.trim(this.props.missing);
+            if (v.length > 0) missingVal = v;
+          }
+          array.forEach(data.buckets,function(entry){
+            this.addEntry(entry.key,entry.doc_count,missingVal);
+          },this);
+        }
+      }
+    }
+    
+  });
+  
+  return oThisClass;
+});

--- a/geoportal/src/main/webapp/app/search/CollectionsFilter.js
+++ b/geoportal/src/main/webapp/app/search/CollectionsFilter.js
@@ -16,13 +16,15 @@ define(["dojo/_base/declare",
         "dojo/_base/lang",
         "dojo/_base/array",
         "dojo/dom-construct",
+        "dojo/topic",
+        "app/context/app-topics",
         "dojo/text!./templates/TermsAggregation.html",
         "dojo/i18n!app/nls/resources",
         "app/search/SearchComponent",
         "app/search/DropPane",
         "app/search/QClause",
         "app/search/CollectionsFilterSettings"], 
-function(declare, lang, array, domConstruct, template, i18n, SearchComponent, 
+function(declare, lang, array, domConstruct, topic, appTopics, template, i18n, SearchComponent, 
   DropPane, QClause, CollectionsFilterSettings) {
   
   var oThisClass = declare([SearchComponent], {
@@ -88,7 +90,10 @@ function(declare, lang, array, domConstruct, template, i18n, SearchComponent,
         parentQComponent: this,
         removable: true,
         scorable: true,
-        query: query
+        query: query,
+        onChange: (status) => {
+          topic.publish(appTopics.CollectionChanged, (status? term: ""));
+        }
       });
       var nd = domConstruct.create("div",{},this.entriesNode);
       var link = domConstruct.create("a",{

--- a/geoportal/src/main/webapp/app/search/CollectionsFilterSettings.js
+++ b/geoportal/src/main/webapp/app/search/CollectionsFilterSettings.js
@@ -1,0 +1,166 @@
+/* See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Esri Inc. licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+define(["dojo/_base/declare",
+        "dojo/_base/lang",
+        "dojo/number",
+        "app/search/SearchComponentSettings",
+        "dojo/text!./templates/TermsAggregationSettings.html",
+        "dojo/i18n!app/nls/resources"], 
+function(declare, lang, number, SearchComponentSettings, template, i18n) {
+  
+  var oThisClass = declare([SearchComponentSettings], {
+    
+    i18n: i18n,
+    templateString: template,
+    
+    maxSize: 10000000,
+    maxMinDocCount: Number.POSITIVE_INFINITY,
+    
+    postCreate: function() {
+      this.inherited(arguments);
+    },
+    
+    _applyTextVal: function(props,name,inputNode) {
+      delete props[name];
+      var v = inputNode.value;
+      if (typeof v === "string") {
+        v = lang.trim(v);
+        if (v.length > 0) props[name] = v;
+      }
+    },
+    
+    _setTextVal: function(props,name,inputNode) {
+      inputNode.value = "";
+      var v = props[name];
+      if (typeof v === "string") {
+        v = lang.trim(v);
+        if (v.length > 0) inputNode.value = v;
+      }
+    },
+    
+    /* SearchComponentSettings API ============================================= */
+    
+    getTitle: function() {
+      return i18n.search.termsAggregation.settings.caption;
+    },
+    
+    init: function(settings) {
+      this.inherited(arguments);
+      if (!settings) settings = this.targetWidget;
+      
+      var v, v2, props = settings.props || {};
+      
+      this.componentLabelInput.value = settings.label;
+      this.fieldInput.value = settings.field;
+      
+      this.sizeInput.value = "";
+      v = number.parse(props.size,{places:0});
+      if (typeof v === "number" && !isNaN(v) && isFinite(v)) {
+        if (v > 0 && v <= this.maxSize) {
+          this.sizeInput.value = v;
+        }
+      }
+      
+      this.minDocCountInput.value = "";
+      v = number.parse(props.min_doc_count,{places:0});
+      if (typeof v === "number" && !isNaN(v) && isFinite(v)) {
+        if (v > 0 && v <= this.maxMinDocCount) {
+          this.minDocCountInput.value = v;
+        }
+      }
+      
+      $(this.orderSelect).val("");
+      v = props.order, v2 = null;
+      if (typeof v === "object" && v !== null) {
+        if (v._count === "asc") {
+          v2 = "countAsc";
+        } else if (v._count === "desc") {
+          v2 = "countDesc";
+        } else if (v._term === "asc") {
+          v2 = "termAsc";
+        } else if (v._term === "desc") {
+          v2 = "termDesc";
+        }
+        if (v2 !== null) $(this.orderSelect).val(v2);
+      }
+      
+      this._setTextVal(props,"missing",this.missingInput);
+      //this._setTextVal(props,"include",this.includeInput);
+      //this._setTextVal(props,"exclude",this.excludeInput);
+    },
+    
+    reset: function() {
+      this.init(this.targetWidget._initialSettings);
+    },
+    
+    validateAndApply: function() {
+      var chkInput = function(inputNode,defaultVal) {
+        var v = inputNode.value;
+        if (typeof v === "string" && lang.trim(v).length > 0) {
+          return lang.trim(v);
+        }
+        return defaultVal;
+      };
+      
+      if (!this.targetWidget.props) this.targetWidget.props = {};
+      var v, v2, props = {}, targetProps = this.targetWidget.props;
+      
+      this.targetWidget.label = chkInput(this.componentLabelInput,this.targetWidget.label);
+      this.targetWidget.dropPane.set("title",this.targetWidget.label);
+      this.targetWidget.field = chkInput(this.fieldInput,this.targetWidget.field);
+      
+      delete targetProps.size;
+      v = number.parse(this.sizeInput.value,{places:0});
+      if (typeof v === "number" && !isNaN(v) && isFinite(v)) {
+        if (v > 0 && v <= this.maxSize) {
+          props.size = v;
+        }
+      } 
+      
+      delete targetProps.min_doc_count;
+      v = number.parse(this.minDocCountInput.value,{places:0});
+      if (typeof v === "number" && !isNaN(v) && isFinite(v)) {
+        if (v > 0 && v <= this.maxMinDocCount) {
+          props.min_doc_count = v;
+        }
+      } 
+      
+      delete targetProps.order;
+      v = this.orderSelect.options[this.orderSelect.selectedIndex].value;
+      if (typeof v === "string" && v.length > 0) {
+        if (v === "countAsc") {
+          props.order = {"_count":"asc"};
+        } else if (v === "countDesc") {
+          props.order = {"_count":"desc"};
+        } else if (v === "termAsc") {
+          props.order = {"_term":"asc"};
+        } else if (v === "termDesc") {
+          props.order = {"_term":"desc"};
+        }
+      }
+      
+      this._applyTextVal(targetProps,"missing",this.missingInput);
+      //this._applyTextVal(targetProps,"include",this.includeInput);
+      //this._applyTextVal(targetProps,"exclude",this.excludeInput);
+
+      lang.mixin(targetProps,props);
+      this.targetWidget.search();
+      this.hideDialog();
+    }
+  
+  });
+  
+  return oThisClass;
+});

--- a/geoportal/src/main/webapp/app/search/ItemCard.js
+++ b/geoportal/src/main/webapp/app/search/ItemCard.js
@@ -41,6 +41,7 @@ define(["dojo/_base/declare",
   "app/context/metadata-editor",
   "app/content/SetAccess",
   "app/content/SetApprovalStatus",
+  "app/content/SetCollections",
   "app/content/SetField",
   "app/content/UploadMetadata",
   "app/preview/PreviewUtil",
@@ -56,7 +57,7 @@ define(["dojo/_base/declare",
 function(declare, lang, array, string, topic, xhr, on, appTopics, domStyle, domClass, domConstruct,
   _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Tooltip, TooltipDialog, popup,
   template, i18n, AppClient, ServiceType, util, ConfirmationDialog, ChangeOwner, DeleteItems,
-  MetadataEditor, gxeConfig, SetAccess, SetApprovalStatus, SetField, UploadMetadata,
+  MetadataEditor, gxeConfig, SetAccess, SetApprovalStatus, SetCollections, SetField, UploadMetadata,
   PreviewUtil, PreviewPane, Map, Extent, SimpleFillSymbol, Point, Graphic, GraphicsLayer) {
 
   var oThisClass = declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
@@ -355,6 +356,7 @@ function(declare, lang, array, string, topic, xhr, on, appTopics, domStyle, domC
       var isPublisher = AppContext.appUser.isPublisher();
       var supportsApprovalStatus = AppContext.geoportal.supportsApprovalStatus;
       var supportsGroupBasedAccess = AppContext.geoportal.supportsGroupBasedAccess;
+      var supportsCollections = AppContext.geoportal.supportsCollections;
       var links = [];
 
       if (this._canEditMetadata(item,isOwner,isAdmin,isPublisher)) {
@@ -401,6 +403,18 @@ function(declare, lang, array, string, topic, xhr, on, appTopics, domStyle, domC
           innerHTML: i18n.content.setApprovalStatus.caption,
           onclick: function() {
             var dialog = new SetApprovalStatus({item:item,itemCard:self});
+            dialog.show();
+          }
+        }));
+      }
+
+      if (supportsCollections && canManage) {
+        links.push(domConstruct.create("a",{
+          "class": "small",
+          href: "javascript:void(0)",
+          innerHTML: i18n.content.setCollections.caption,
+          onclick: function() {
+            var dialog = new SetCollections({item:item,itemCard:self});
             dialog.show();
           }
         }));

--- a/geoportal/src/main/webapp/app/search/QClause.js
+++ b/geoportal/src/main/webapp/app/search/QClause.js
@@ -30,7 +30,10 @@ function(declare,lang) {
     constructor: function(args){
       lang.mixin(this,args);
       this.clauseId = oThisClass._staticCounter++;
-    }
+    },
+    
+    // status: false - deleted, true - added
+    onChange: function(status) {}
 
   });
 

--- a/geoportal/src/main/webapp/app/search/SearchComponent.js
+++ b/geoportal/src/main/webapp/app/search/SearchComponent.js
@@ -66,18 +66,29 @@ function(declare, lang, array, topic, appTopics, Templated, util) {
     },
     
     checkCollection: function(allowedCollection, publishedCollection) {
-      var isNot = false;
-
       if (allowedCollection==="*" && publishedCollection.length>0) {
         return true;
       }
       
-      if (allowedCollection.startsWith("!")) {
-        isNot = true;
-        allowedCollection = allowedCollection.substr(1);
+      
+      if (allowedCollection.startsWith("/")) {
+        
+        var exp = eval(allowedCollection);
+        return exp.test(publishedCollection);
+        
+      } else {
+        
+        var isNot = false;
+
+        if (allowedCollection.startsWith("!")) {
+          isNot = true;
+          allowedCollection = allowedCollection.substr(1);
+        }
+        
+        return allowedCollection===publishedCollection? !isNot: isNot;
+        
       }
 
-      return allowedCollection===publishedCollection? !isNot: isNot;
     },
     
     appendQClauses: function(params) {

--- a/geoportal/src/main/webapp/app/search/templates/AppliedFilter.html
+++ b/geoportal/src/main/webapp/app/search/templates/AppliedFilter.html
@@ -1,7 +1,7 @@
 <span class="g-applied-filter" title="${tip}">
   <span>${label}</span>
 
-  <a href="#" title="Clear Filter" style="visibility:${visibility};"
+  <a href="#" title="Clear Filter" style="visibility: '${visibility}';"
     data-dojo-attach-event="onclick: clearFilter">
     <svg viewBox="0 0 24 24">
       <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />

--- a/geoportal/src/main/webapp/app/search/templates/CollectionsFilter.html
+++ b/geoportal/src/main/webapp/app/search/templates/CollectionsFilter.html
@@ -1,0 +1,7 @@
+<div>
+	<div class="g-drop-pane" data-dojo-type="app/search/DropPane" 
+	  data-dojo-attach-point="dropPane"
+	  data-dojo-props="title:'${label}',open:${open}">
+	  <div class="g-entries g-entry-links" data-dojo-attach-point="entriesNode"></div>
+	</div>
+</div>

--- a/geoportal/src/main/webapp/app/search/templates/CollectionsFilterSettings.html
+++ b/geoportal/src/main/webapp/app/search/templates/CollectionsFilterSettings.html
@@ -1,0 +1,89 @@
+<div class="g-settings-pane g-labels-right">
+  <div class="form-group form-group-sm">
+    <label for="${id}_componentLabel" class="control-label col-sm-3"
+      >${i18n.search.componentSettings.componentLabel}</label>
+    <div class="col-sm-8">
+      <input id="${id}_componentLabel" type="text" class="form-control input-sm g-input-text" 
+        placeholder="${i18n.search.componentSettings.componentLabelPlaceholder}"
+        data-dojo-attach-point="componentLabelInput" >
+    </div>
+  </div>
+  <div class="form-group form-group-sm">
+    <label for="${id}_field" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.field}</label>
+    <div class="col-sm-8">
+	    <input id="${id}_field" type="text" class="form-control g-input-text" 
+	      placeholder="${i18n.search.termsAggregation.settings.fieldPlaceholder}"
+	      data-dojo-attach-point="fieldInput" >
+    </div>
+  </div>
+	<div class="form-group form-group-sm">
+	  <label for="${id}_size" class="control-label col-sm-3"
+	   >${i18n.search.termsAggregation.settings.size}</label>
+	  <div class="col-sm-8">
+		  <input id="${id}_size" type="text" class="form-control g-input-number" 
+		    placeholder="${i18n.search.termsAggregation.settings.sizePlaceholder}"
+		    data-dojo-attach-point="sizeInput" >
+    </div>
+	</div>
+  <div class="form-group form-group-sm">
+    <label for="${id}_minDocCount" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.minDocCount}</label>
+    <div class="col-sm-8">
+	    <input id="${id}_minDocCount" type="text" class="form-control g-input-number" 
+	      placeholder="${i18n.search.termsAggregation.settings.minDocCountPlaceholder}"
+	      data-dojo-attach-point="minDocCountInput">
+    </div>
+  </div>
+  <div class="form-group form-group-sm">
+    <label for="${id}_missing" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.missing}</label>
+    <div class="col-sm-8">
+	    <input id="${id}_missing" type="text" class="form-control g-input-text" 
+	      placeholder="${i18n.search.termsAggregation.settings.missingPlaceholder}"
+	      data-dojo-attach-point="missingInput">
+    </div>
+  </div>
+  <!-- 
+  <div class="form-group form-group-sm">
+    <label for="${id}_include" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.include}</label>
+    <div class="col-sm-8">
+	    <input id="${id}_include" type="text" class="form-control g-input-text" 
+	      placeholder="${i18n.search.termsAggregation.settings.includePlaceholder}"
+	      data-dojo-attach-point="includeInput">
+    </div>
+  </div>
+  <div class="form-group form-group-sm">
+    <label for="${id}_exclude" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.exclude}</label>
+    <div class="col-sm-8">
+	    <input id="${id}_exclude" type="text" class="form-control g-input-text" 
+	      placeholder="${i18n.search.termsAggregation.settings.excludePlaceholder}"
+	      data-dojo-attach-point="excludeInput">
+    </div>
+  </div>
+  -->
+  <div class="form-group form-group-sm">
+    <label for="${id}_sel1" class="control-label col-sm-3"
+      >${i18n.search.termsAggregation.settings.order.label}</label>
+    <div class="col-sm-8">
+			<select id="${id}_sel1" class="form-control" data-dojo-attach-point="orderSelect">
+			  <option value="">${i18n.search.termsAggregation.settings.order.placeholder}</option>
+			  <option value="countDesc">${i18n.search.termsAggregation.settings.order.countDesc}</option>
+			  <option value="countAsc">${i18n.search.termsAggregation.settings.order.countAsc}</option>
+	      <option value="termAsc">${i18n.search.termsAggregation.settings.order.termAsc}</option>
+	      <option value="termDesc">${i18n.search.termsAggregation.settings.order.termDesc}</option>
+			</select>
+    </div>
+  </div>
+  <div class="form-group form-group-sm">
+    <div class="col-sm-3"></div>
+    <div class="col-sm-8" style="margin-top:10px;">
+      <a href="javascript:void(0)"
+        data-dojo-attach-event="onClick: reset">
+        ${i18n.search.componentSettings.reset}
+      </a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## General information
This pull request provides basic functionality for collections support. Main features are:
1. Configurable - functionality could be enabled or disabled as requested,
2. Ad hoc - collections could be added and deleted ad-hoc without elaborated configuration,
3. Facets selection - selection of facets displayed on the screen can be determined upon selected selection.

## Configuration
### Enable collections feature
1. Edit `app-context.xml` configuration file,
2. Locate `supportsCollections` property within the `geoportalContext` bean,
3. Change value of the property to `true`,

### Configure facets
Each facet can be configured to react to the selection of the collection. It will appear or it will be removed from the screen depending how it is configured and which collection has been selected by the user.

Configuration is done entirely through `SearchPanel.html`. Each facet is represented by any `<div>` element placed within parent <div> marked with `class="g-search-pane-left"`. Every facet is equipped with `data-dojo-props` property which is a comma separated list of configuration properties passed to facet object. In order to configure facet to react to user choice of collections, property named `allowedCollections` shall be added, for example:

```
<div class="g-filter-collapse" data-dojo-type="app/search/TemporalFilter"
  data-dojo-props="
    allowedCollections: ['data'],
    nestedPath:'timeperiod_nst',
    field:'timeperiod_nst.begin_dt',
    toField:'timeperiod_nst.end_dt',
    interval:'year',
    open:false,
    label:'${i18n.search.criteria.timePeriod}'">
</div>
```

### allowedCollections syntax
1. It has to be mentioned first that `allowedCollections `is a list of conditions which would turn facet on. It is enough to have one condition passing with multiple conditions failing to be able to turn facet on. For example:
```
allowedCollections: ['data','private']
```
will turn facet on if and only if one of the collections: 'data' or 'private' is selected by the user. Any other selection of collection or not having selected any of the collections will turn facet off.

2. For simplicity it is allowed to declare allowed collections without square brackets if facet should be activated for only one collection, for example:
```
allowedCollections: 'data'
```

3. Note that `allowedCollections: ['data']` will turn facet on only if user selected 'data' collection, but it will remain inactive if user did not select any collection. In order to express condition that facet shall be active if user eider selected particular collection or did not select any, empty string could be used, for example:
```
allowedCollections: ['','data']
```

4. It is also allowed to user '*' wildcard to express situation if facet should be turned on for any collection but turned off if not collection has been selected:
```
allowedCollections: ['*']
```

5. Condition could be negated by placing '!' in front of collection name, like below:
```
allowedCollections: ['!data']
```
In this case facet will be activated if any collection is selected except 'data' collection or if no collection has been selected.

6. Finally, each condition could be expressed using regular expressions, like below:
```
allowedCollections: ['/d.+/i']
```
This condition will react to any collection which name starts with the letter 'd' regardless whether it is lower or upper case.

