### PR TITLE
Remove Content-Type header for HTTP GET requests

### DIFF
--- a/components/CswClient/Pro/CswClient/Common/CswClient.cs
+++ b/components/CswClient/Pro/CswClient/Common/CswClient.cs
@@ -93,7 +93,9 @@ namespace com.esri.gpt.csw
                 request.Method = "GET";                             
             }
             else{
-                request.ContentType = "text/xml; charset=UTF-8"; 
+                if(!method.Equals("GET")){
+                  request.ContentType = "text/xml; charset=UTF-8"; 
+                }
                 request.Method = method;
             }
 


### PR DESCRIPTION
Avoid sending http header Content-Type for HTTP GET requests since this is typically not allowed because GET requests do not include body content.

Closes #384
