### PR TITLE
Fix #393 Missing result entry in CSW Client

### DIFF
--- a/components/CswClient/Pro/CswClient/Dockpane1.xaml.cs
+++ b/components/CswClient/Pro/CswClient/Dockpane1.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Resources;
 using System.Windows;
@@ -266,7 +266,7 @@ namespace GeoportalSearch
         {
 
           List<CswRecord> listItems = new List<CswRecord>();
-          for (int i = 0; i < alRecords.Count - 1; i++)
+          for (int i = 0; i < alRecords.Count; i++)
           {
             listItems.Add((CswRecord)alRecords[i]);
           }


### PR DESCRIPTION
fixes #393 by removing "-1" from for loop which made the loop stop one step too early while adding records to the GUI list.