### PR TITLE
Fix #394 Use content search feature in CSW Client

### DIFF
--- a/components/CswClient/Pro/CswClient/Dockpane1.xaml.cs
+++ b/components/CswClient/Pro/CswClient/Dockpane1.xaml.cs
@@ -638,7 +638,7 @@ namespace GeoportalSearch
     /// <returns>view extent as an envelope object</returns>
     private com.esri.gpt.csw.Envelope CurrentMapViewExtent()
     {
-      com.esri.gpt.csw.Envelope envCurrentViewExent = null;
+      com.esri.gpt.csw.Envelope envCurrentViewExent = new com.esri.gpt.csw.Envelope();
       ArcGIS.Core.Geometry.Envelope extent = null;
 
       if(MapView.Active != null)


### PR DESCRIPTION
Variable needs to be initialised with Envelope constructor in order to be able to set MinX etc. from currently loaded map. If not, an exception occurs (that is ignored via a try/catch)

fixes #394 