### PR TITLE
Fix wildcard character while querying using CSW_2.0.2_APISO_GICAT

### DIFF
--- a/components/CswClient/CswProfiles/CSW_2.0.2_APISO_GICAT_GetRecords_Request.xslt
+++ b/components/CswClient/CswProfiles/CSW_2.0.2_APISO_GICAT_GetRecords_Request.xslt
@@ -176,7 +176,7 @@
 		<xsl:variable name="remaining" select="substring-after($newlist, ' ')" />
 		<xsl:if test="not(contains($first,'from:') or contains($first,'to:'))">
 		  <xsl:value-of select="$first" />
-		  <xsl:text>+</xsl:text>
+		  <xsl:text>*</xsl:text>
 		</xsl:if>
 		<xsl:if test="$remaining">
 			<xsl:call-template name="output-keywords">


### PR DESCRIPTION
Fixes #398 by using `*`as wildcard character consistently.

The XSLT transform for profile CSW_2.0.2_APISO_GICAT has inconsistent use of wildcard characters which causes it to fail matching any entries.

In the /GetRecords/KeyWord section, `*` is specified as the wildcard character to be used:
```
	<!-- key word search -->
	<xsl:template match="/GetRecords/KeyWord" xmlns:ogc="http://www.opengis.net/ogc">
		<xsl:if test="normalize-space(.)!=''">
			<ogc:PropertyIsLike escapeChar="!" singleChar="#" wildCard="*">
				<ogc:PropertyName>apiso:AnyText</ogc:PropertyName>
				<ogc:Literal>
					<xsl:call-template name="output-keywords">
						<xsl:with-param name="list"><xsl:value-of select="." /></xsl:with-param>
					</xsl:call-template>
				</ogc:Literal>
			</ogc:PropertyIsLike>
		</xsl:if>
		<xsl:if test="normalize-space(.)=''">
            <ogc:PropertyIsLike escapeChar="!" singleChar="#" wildCard="*">
                <ogc:PropertyName>apiso:AnyText</ogc:PropertyName>
                <ogc:Literal>
                    <xsl:call-template name="output-keywords">
                        <xsl:with-param name="list">*</xsl:with-param>
                    </xsl:call-template>
                </ogc:Literal>
            </ogc:PropertyIsLike>
        </xsl:if>
	</xsl:template>
```
But in the output-keywords section on line https://github.com/Esri/geoportal-server-catalog/blob/master/components/CswClient/CswProfiles/CSW_2.0.2_APISO_GICAT_GetRecords_Request.xslt#L179 where the wildcard character is added to the request it adds `+` instead of `*`.
```
	<xsl:template name="output-keywords">
		<xsl:param name="list" />
		<xsl:variable name="newlist" select="concat(normalize-space($list), ' ')" />
		<xsl:variable name="first" select="substring-before($newlist, ' ')" />
		<xsl:variable name="remaining" select="substring-after($newlist, ' ')" />
		<xsl:if test="not(contains($first,'from:') or contains($first,'to:'))">
		  <xsl:value-of select="$first" />
		  <xsl:text>+</xsl:text>
		</xsl:if>
		<xsl:if test="$remaining">
			<xsl:call-template name="output-keywords">
				<xsl:with-param name="list" select="$remaining" />
			</xsl:call-template>
		</xsl:if>
	</xsl:template>
```
