### PR TITLE
Enable Add to map in CSW Client 'opportunistic' when type queries are…

### DIFF
--- a/components/CswClient/Pro/CswClient/Common/CswProfile.cs
+++ b/components/CswClient/Pro/CswClient/Common/CswProfile.cs
@@ -345,18 +345,26 @@ namespace com.esri.gpt.csw
                         record.BoundingBox.Minx = 500.00;
                         record.BoundingBox.Maxy = 500.00;
                     }
-                    XmlNode node = xmlnode.SelectSingleNode("Type");
-                    if (node != null)
-                    {
-                        record.IsLiveDataOrMap = node.InnerText.Equals("liveData", StringComparison.OrdinalIgnoreCase);
-                        if (!record.IsLiveDataOrMap)
-                        {
-                            record.IsLiveDataOrMap = node.InnerText.Equals("downloadableData", StringComparison.OrdinalIgnoreCase);
-                        }
+                    if (filter_livedatamap) { // I.e. the profile has XML attribute SupportContentTypeQuery == True
+                      XmlNode node = xmlnode.SelectSingleNode("Type");
+                      if (node != null)
+                      {
+                          record.IsLiveDataOrMap = node.InnerText.Equals("liveData", StringComparison.OrdinalIgnoreCase);
+                          if (!record.IsLiveDataOrMap)
+                          {
+                              record.IsLiveDataOrMap = node.InnerText.Equals("downloadableData", StringComparison.OrdinalIgnoreCase);
+                          }
+                      }
+                      else
+                      {
+                          // If content type queries are supported by profile but Type was not available, do not enable the Add to map button
+                          record.IsLiveDataOrMap = false;
+                      }
                     }
                     else
                     {
-                        record.IsLiveDataOrMap = false;
+                      // Default to allow Add to map when catalog does not support type queries
+                      record.IsLiveDataOrMap = true;
                     }
 
 


### PR DESCRIPTION
… not supported by profile (i.e. has the parameter `SupportContentTypeQuery = False`.

This means that the existing logic to find any URL (in the References section of the transformed XML) is used. If a MapServerURL is found it asks ArcGIS Pro to add it as a new layer.

For catalogs supporting type queries previous behaviour is kept, i.e. if Type is not provided or if Type is not `liveData` or `downloadableData` Add to map button is not enabled.

fixes #397 (at least provides a reasonable workaround for it)
