### PR TITLE
Add support for dynamic maps to the search map in addition to tiled

### DIFF
--- a/geoportal/src/main/webapp/app/context/app-config.js
+++ b/geoportal/src/main/webapp/app/context/app-config.js
@@ -1,38 +1,39 @@
 define([],function(){var obj={
 // .......................................................................................
-  
+
   system: {
     searchLimit: 10000
   },
-  
+
   edit: {
     setField: {
       allow: false,
       adminOnly: false
     }
   },
-  
+
   bulkEdit: {
     allowByOwner: true,
     allowBySourceUri: true,
     allowByTaskRef: true,
     allowByQuery: true
   },
-  
+
   search: {
     allowSettings: true,
     useSimpleQueryString: false,
     escapeFilter: false
   },
-  
+
   searchMap: {
     basemap: "streets",
-    autoResize: true, 
+    isTiled: false,
+    autoResize: true,
     wrapAround180: true,
-    center: [-98, 40], 
+    center: [-98, 40],
     zoom: 3
   },
-  
+
   searchResults: {
     numPerPage: 10,
     showDate: true,
@@ -47,12 +48,12 @@ define([],function(){var obj={
     showOpenSearchLinks: true,
     showTotalCountInHierarchy: true
   },
-  
+
   statusChecker: {
     apiUrl: "http://registry.fgdc.gov/statuschecker/api/v2/results?",
     infoUrl: "http://registry.fgdc.gov/statuschecker/ServiceDetail.php?",
     authKey: null
   }
-  
+
 // .......................................................................................
 };return obj;});

--- a/geoportal/src/main/webapp/app/search/SpatialFilter.js
+++ b/geoportal/src/main/webapp/app/search/SpatialFilter.js
@@ -35,6 +35,7 @@ define(["dojo/_base/declare",
         "app/search/SpatialFilterSettings",
         "esri/map",
         "esri/layers/ArcGISTiledMapServiceLayer",
+        "esri/layers/ArcGISDynamicMapServiceLayer",
         "esri/layers/GraphicsLayer",
         "esri/geometry/webMercatorUtils",
         "esri/geometry/Extent",
@@ -55,7 +56,7 @@ define(["dojo/_base/declare",
         "esri/tasks/locator"],
 function(declare, lang, array, aspect, djQuery, on, domConstruct, domClass, domGeometry, domStyle, djNumber,
     topic, appTopics, template, i18n, SearchComponent, DropPane, QClause, GeohashEx, util, Settings, Map,
-    ArcGISTiledMapServiceLayer, GraphicsLayer, webMercatorUtils, Extent, Point, SpatialReference,
+    ArcGISTiledMapServiceLayer, ArcGISDynamicMapServiceLayer, GraphicsLayer, webMercatorUtils, Extent, Point, SpatialReference,
     SimpleMarkerSymbol, SimpleLineSymbol, SimpleFillSymbol, PictureMarkerSymbol, ClassBreaksRenderer,
     SimpleRenderer, Graphic, Color, PopupTemplate, InfoTemplate, SearchWidget, Deferred, Locator) {
 
@@ -403,13 +404,22 @@ function(declare, lang, array, aspect, djQuery, on, domConstruct, domClass, domG
       if (typeof mapProps.basemap === "string" && mapProps.basemap.length > 0) {
         v = null;
       }
+
+
       this.map = null;
       var map = new Map(this.mapNode,mapProps);
       if (typeof v === "string" && v.length > 0) {
         v =  util.checkMixedContent(v);
-        var basemap = new ArcGISTiledMapServiceLayer(v);
+        var basemap;
+        if (!mapProps.isTiled) {
+          basemap = new ArcGISDynamicMapServiceLayer(v);
+        } else {
+          basemap = new ArcGISTiledMapServiceLayer(v);
+        }
         map.addLayer(basemap);
       }
+
+
       this.own(on(map,"Load",lang.hitch(this,function(){
         this.map = map;
         this.initializeLocator();


### PR DESCRIPTION
Uses the attribute isTiled: true/false
- false to call ArcGISDynamicMapServiceLayer
- true to call ArcGISTiledMapServiceLayer

Keeps tiled as default if not specified.