### PR TITLE
add AppClient reference

### DIFF
--- a/geoportal/src/main/webapp/app/search/CollectionsFilter.js
+++ b/geoportal/src/main/webapp/app/search/CollectionsFilter.js
@@ -25,9 +25,10 @@ define(["dojo/_base/declare",
         "app/search/SearchComponent",
         "app/search/DropPane",
         "app/search/QClause",
-        "app/search/CollectionsFilterSettings"], 
+        "app/search/CollectionsFilterSettings",
+        "app/context/AppClient"], 
 function(declare, lang, array, domConstruct, domClass, dojoRequest, topic, appTopics, template, i18n, SearchComponent, 
-  DropPane, QClause, CollectionsFilterSettings) {
+  DropPane, QClause, CollectionsFilterSettings, AppClient) {
   
   var oThisClass = declare([SearchComponent], {
     


### PR DESCRIPTION
when approval status or group-based access are on, the app creates a new AppClient. The reference to this class was missing causing an error