### PR TITLE
swagger file fixes

### DIFF
--- a/geoportal/src/main/webapp/api/gpt_api.json
+++ b/geoportal/src/main/webapp/api/gpt_api.json
@@ -77,7 +77,7 @@
             "description": "CRS to return collection geometries in",
             "required": false,
             "type": "string",
-            "example": "EPSG:3857"
+            "default": "EPSG:3857"
           },
           {
             "name": "f",
@@ -85,7 +85,7 @@
             "description": "Output format of the collections list",
             "required": false,
             "type": "string",
-            "example": "geojson"
+            "default": "geojson"
           }
         ],
         "responses": {
@@ -156,7 +156,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "outCRS",
@@ -164,7 +164,7 @@
             "description": "CRS to return collection geometries in",
             "required": false,
             "type": "string",
-            "example": "EPSG:3857"
+            "default": "EPSG:3857"
           }
         ],
         "responses": {
@@ -187,7 +187,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           }			
         ],
         "responses": {
@@ -215,7 +215,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "limit",
@@ -223,7 +223,7 @@
             "description": "Minimum = 1. Maximum = 10000, Default = 10.",
             "required": false,
             "type": "integer",
-            "example": 15
+            "default": 15
           },
           {
             "name": "bbox",
@@ -231,7 +231,7 @@
             "description": "Only features that have a geometry that intersects the bounding box are selected.",
             "required": false,
             "type": "ArrayofNumbers",
-            "example": "-171.791110603,18.91619,-66.96466,71.3577635769"
+            "default": "-171.791110603,18.91619,-66.96466,71.3577635769"
           },
           {
             "name": "datetime",
@@ -239,7 +239,7 @@
             "description": "Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.",
             "required": false,
             "type": "String",
-            "example": "2023-06-12T23:20:50Z/.."
+            "default": "2023-06-12T23:20:50Z/.."
           },
           {
             "name": "outCRS",
@@ -247,7 +247,7 @@
             "description": "CRS to return item geometries in",
             "required": false,
             "type": "string",
-            "example": "EPSG:3857"
+            "default": "EPSG:3857"
           }
         ],
         "responses": {
@@ -273,7 +273,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "body",
@@ -305,7 +305,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "ids",
@@ -313,7 +313,7 @@
             "description": "Comma separated list of Stac item id",
             "required": false,
             "type": "string",
-            "example": "test_87,test_88"
+            "default": "test_87,test_88"
           },
           {
             "name": "deleteCollection",
@@ -321,7 +321,7 @@
             "description": "Default is false. If true, collection will also be deleted. Cannot be used if ids provided.",
             "required": false,
             "type": "boolean",
-            "example": "true or false"
+            "default": "true or false"
           }
         ],
         "responses": {
@@ -349,7 +349,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "id",
@@ -357,7 +357,7 @@
             "description": "Stac item id",
             "required": true,
             "type": "string",
-            "example": "LC80100252015082LGN00"
+            "default": "LC80100252015082LGN00"
           },
           {
             "name": "outCRS",
@@ -365,7 +365,7 @@
             "description": "CRS to return item geometries in",
             "required": false,
             "type": "string",
-            "example": "EPSG:3857"
+            "default": "EPSG:3857"
           }
         ],
         "responses": {
@@ -391,7 +391,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "id",
@@ -399,7 +399,7 @@
             "description": "STAC item id",
             "required": true,
             "type": "string",
-            "example": "LC80100252015082LGN00"
+            "default": "LC80100252015082LGN00"
           },
           {
             "name": "body",
@@ -431,7 +431,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },
           {
             "name": "id",
@@ -439,7 +439,7 @@
             "description": "STAC item id",
             "required": true,
             "type": "string",
-            "example": "LC80100252015082LGN00"
+            "default": "LC80100252015082LGN00"
           },
           {
             "name": "body",
@@ -471,7 +471,7 @@
             "description": "Collection id",
             "required": true,
             "type": "string",
-            "example": "metadata"
+            "default": "metadata"
           },          
           {
             "name": "id",
@@ -479,7 +479,7 @@
             "description": "Stac item id",
             "required": true,
             "type": "string",
-            "example": "LC80100252015082LGN00"
+            "default": "LC80100252015082LGN00"
           }
         ],
         "responses": {
@@ -507,7 +507,7 @@
             "description": "Comma separated Collection id",
             "required": false,
             "type": "string",
-            "example": "metadata,test"
+            "default": "metadata,test"
           },          
           {
             "name": "limit",
@@ -515,7 +515,7 @@
             "description": "Minimum = 1. Maximum = 10000, Default = 10.",
             "required": false,
             "type": "integer",
-            "example": 15
+            "default": 15
           },
           {
             "name": "bbox",
@@ -523,7 +523,7 @@
             "description": "Only features that have a geometry that intersects the bounding box are selected.s",
             "required": false,
             "type": "Array of Numbers",
-            "example": "-171.791110603,18.91619,-66.96466,71.3577635769"
+            "default": "-171.791110603,18.91619,-66.96466,71.3577635769"
           },
           {
             "name": "intersects",
@@ -531,7 +531,7 @@
             "description": "pointGeoJSON (object) or multipointGeoJSON (object) or linestringGeoJSON (object) or multilinestringGeoJSON (object) or polygonGeoJSON (object) or multipolygonGeoJSON (object) or geometrycollectionGeoJSON (object) (geometryGeoJSON)",
             "required": false,
             "type": "GeoJSON object",
-            "example": "{\"type\":\"Polygon\",\"coordinates\":[[[-67.18661657269904,48.297014795971687],[-67.1872,48.2971],[-67.17322376288064,48.33374073671041],[-67.1590065133506,48.371013322480617],[-66.6453207034186,49.7177153248036],[-66.63275537806288,49.750657151284347],[-66.6171,49.7917],[-66.61637825143734,49.79159448137363],[-64.1246,49.4273],[-64.14045802174776,49.39048646945745],[-64.74832861700387,47.979348114350958],[-64.7639,47.9432],[-67.18661657269904,48.297014795971687]]]}"
+            "default": "{\"type\":\"Polygon\",\"coordinates\":[[[-67.18661657269904,48.297014795971687],[-67.1872,48.2971],[-67.17322376288064,48.33374073671041],[-67.1590065133506,48.371013322480617],[-66.6453207034186,49.7177153248036],[-66.63275537806288,49.750657151284347],[-66.6171,49.7917],[-66.61637825143734,49.79159448137363],[-64.1246,49.4273],[-64.14045802174776,49.39048646945745],[-64.74832861700387,47.979348114350958],[-64.7639,47.9432],[-67.18661657269904,48.297014795971687]]]}"
           },
           {
             "name": "datetime",
@@ -539,7 +539,7 @@
             "description": "Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots",
             "required": false,
             "type": "String",
-            "example": "2023-06-12T23:20:50Z/.."
+            "default": "2023-06-12T23:20:50Z/.."
           },
 
           {
@@ -548,7 +548,7 @@
             "description": "Comma separated list of Item ids to return.",
             "required": false,
             "type": "Comma separated list of Item ids to return",
-            "example": "LC80100252015082LGN00,LC80100252014287LGN00"
+            "default": "LC80100252015082LGN00,LC80100252014287LGN00"
           },
           {
             "name": "status",
@@ -556,7 +556,7 @@
             "description": "Feature status (valid values are active/ inactive)",
             "required": false,
             "type": "string",
-            "example": "active | inactive"
+            "default": "active | inactive"
           },
           {
             "name": "outCRS",
@@ -564,7 +564,7 @@
             "description": "CRS to return item geometries in",
             "required": false,
             "type": "string",
-            "example": "EPSG:3857"
+            "default": "EPSG:3857"
           },
           {
             "name": "filter",
@@ -572,7 +572,7 @@
             "description": "A filter to be applied to the search using one of the STAC item properties, for example status=active",
             "required": false,
             "type": "string",
-            "example": "status=active"
+            "default": "status=active"
           }
         ],
         "responses": {
@@ -597,7 +597,9 @@
             "in": "body",
             "description": "https://api.stacspec.org/v1.0.0/item-search/#tag/Item-Search/operation/postItemSearch",
             "required": true,
-            "example": "{\"bbox\":[-66.6459,49.354,-63.4856,51.2101],\"datetime\":\"2018-02-12T00:00:00Z/2023-07-18T12:31:12Z\",\"intersects\":{\"type\":\"Polygon\",\"coordinates\":[[[-67.18661657269904,48.297014795971687],[-67.1872,48.2971],[-67.17322376288064,48.33374073671041],[-67.1590065133506,48.371013322480617],[-66.6453207034186,49.7177153248036],[-66.63275537806288,49.750657151284347],[-66.6171,49.7917],[-66.61637825143734,49.79159448137363],[-64.1246,49.4273],[-64.14045802174776,49.39048646945745],[-64.74832861700387,47.979348114350958],[-64.7639,47.9432],[-67.18661657269904,48.297014795971687]]]},\"ids\":[\"LC80100252015082LGN00\",\"LC80100252014287LGN00\"],\"limit\":10,\"collections\":[\"metadata\",\"test\"],\"outCRS\":\"EPSG:3857\",\"status\":\"inactive\"}"
+            "schema": {
+              "$ref": "#/definitions/STACSearchRequest"
+            }
           }
         ],
         "responses": {
@@ -691,7 +693,7 @@
             "description": "Minimum = 1. Maximum = 10000, Default = 10.",
             "required": false,
             "type": "integer",
-            "example": 15
+            "default": 15
           },
           {
             "name": "querydsl",
@@ -699,7 +701,7 @@
             "description": "Features matching the supplied query (JSON Elasticsearch Query DSL).Other querables are ignored.",
             "required": false,           
             "type": "Json string",
-            "example": "{\"query\":{\"bool\": {\"must\":[{\"match\":{\"sys_owner_s\":\"admin\"}}]}}}"
+            "default": "{\"query\":{\"bool\": {\"must\":[{\"match\":{\"sys_owner_s\":\"admin\"}}]}}}"
           },
           {
             "name": "bbox",
@@ -707,7 +709,7 @@
             "description": "Only features that have a geometry that intersects the bounding box are selected.",
             "required": false,
             "type": "ArrayofNumbers",
-            "example": "-171.791110603,18.91619,-66.96466,71.3577635769"
+            "default": "-171.791110603,18.91619,-66.96466,71.3577635769"
           },
           {
             "name": "title",
@@ -715,7 +717,7 @@
             "description": "Only features with title are selected",
             "required": false,
             "type": "String",
-            "example": "SampleFeatureService"
+            "default": "SampleFeatureService"
           },
           {
             "name": "provider",
@@ -723,7 +725,7 @@
             "description": "Only features owned by this provider will be selected",
             "required": false,
             "type": "String",
-            "example": "admin"
+            "default": "admin"
           },
           {
             "name": "datetime",
@@ -731,7 +733,7 @@
             "description": "Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.",
             "required": false,
             "type": "String",
-            "example": "2023-06-12T23:20:50Z/.."
+            "default": "2023-06-12T23:20:50Z/.."
           }
         ],
         "responses": {
@@ -756,7 +758,7 @@
             "description": "Ogcrecords item id",
             "required": true,
             "type": "string",
-            "example": "LC80100252015082LGN00"
+            "default": "LC80100252015082LGN00"
           }
         ],
         "responses": {
@@ -782,27 +784,31 @@
             "name": "username",
             "in": "query",
             "description": "User name",
-            "required": true      
+            "required": true,
+            "type": "string"      
           },
           {
             "name": "password",
             "in": "query",
             "description": "User password. For ArcGIS Portal authentication, prefix ArcGIS token with \\__rtkn\\__:",
-            "required": true      
+            "required": true,
+            "type": "string"      
           },
           {
             "name": "client_id",
             "in": "query",
             "description": "Client id for token. This will always be geoportal-client",
             "required": true,
-            "example": "geoportal-client"     
+            "type": "string",
+            "default": "geoportal-client"     
           },
           {
             "name": "grant_type",
             "in": "query",
             "description": "Grant type for token. This will always be password",
             "required": true,
-            "example": "password"    
+            "type": "string",
+            "default": "password"    
           }
         ],
         "responses": {
@@ -2086,6 +2092,18 @@
     }
   },
   "definitions": {
+    "STACSearchRequest": {
+      "type": "object",
+      "properties": {
+        "bbox": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "default": [-180, -90, 180, 90]
+        }
+      }
+    },    
     "GetRecords": {
       "type": "object",
       "xml": {


### PR DESCRIPTION
updated to pass validation at: 

for regular geospatial metadata catalog:
https://[validator.swagger.io/validator/debug?url=https%3A%2F%2Fgpt.geocloud.com%2Fgeoportal3%2Fapi%2Fgpt_api.json](https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fgpt.geocloud.com%2Fgeoportal3%2Fapi%2Fgpt_api.json)

and for STAC

https://[validator.swagger.io/validator/debug?url=https%3A%2F%2Fgpt.geocloud.com%2Fsentinel%2Fapi%2Fgpt_api.json](https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fgpt.geocloud.com%2Fsentinel%2Fapi%2Fgpt_api.json)