### PR TITLE
Update collection path in stac-items.json

### DIFF
--- a/geoportal/src/main/resources/service/config/stac-items.json
+++ b/geoportal/src/main/resources/service/config/stac-items.json
@@ -10,7 +10,7 @@
   "featurePropPath": {
     "type": "Feature",	
     "id": "$._source.id",
-    "collection": "$._source.src_collections_s[0]",		
+    "collection": "$._source.collection",		
     "stac_version": "1.0.0",
     "stac_extensions": [
       "https://stac-extensions.github.io/eo/v2.0.0/schema.json",


### PR DESCRIPTION
src_collection_s is storing title(#710) so this field needs to point to collectionId which is populated while adding item.
All customer copies of stac-items.json should also be updated